### PR TITLE
Added Cookie to restricted headers

### DIFF
--- a/cleantalk.csharp/Cleantalk.cs
+++ b/cleantalk.csharp/Cleantalk.cs
@@ -164,7 +164,7 @@ namespace cleantalk.csharp
                 var context = HttpContext.Current;
                 if (context != null)
                 {
-                    var restrictedHeaders = new[] { "Content-Length", "Connection" };
+                    var restrictedHeaders = new[] { "Content-Length", "Connection", "Cookie" };
                     var h = context.Request.Headers;
                     foreach (var v in
                         h.Keys.Cast<string>()


### PR DESCRIPTION
The cookies from my site were causing a 400 response, so I needed to eliminate them from the data passed through to the API. Beyond that, cookies seem to be data that should not be shared in this way.